### PR TITLE
Appended freehep repository to pom.xml 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,10 @@
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>
+        <repository>
+            <id>freehep</id>
+            <url>https://java.freehep.org/maven2</url>
+        </repository>
     </repositories>
 
     <dependencies>


### PR DESCRIPTION
Fixing Maven's CVE-2021-26291: "The decision was made to block external HTTP repositories by default."

Fixed by adding freehep's maven repo to the pom.xml instead of allowing Jitpack to resolve it via HTTP.